### PR TITLE
Jcwork3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - release
+  - 0.4
 notifications:
   email: true
 before_install:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -8,5 +8,10 @@ if !haskey(pkg_dict, "ODLCommonTools")
   run(`./download.sh`)
   Pkg.build("ODLCommonTools")
 end
+cd(start_dir)
 
+# get the right commit of ArrayViews (before the aview change)
+dir = Pkg.dir("ArrayViews")
+cd(dir)
+run(`git checkout 93e80390aeedb1dbcd90281b6dff7f760f430bc8`)
 cd(start_dir)

--- a/src/SummationByParts.jl
+++ b/src/SummationByParts.jl
@@ -5,6 +5,7 @@ using ArrayViews
 using ODLCommonTools
 import ODLCommonTools.sview
 
+include("compile_time.jl")
 include("orthopoly.jl")
 include("symcubatures.jl")
 include("cubature.jl")

--- a/src/SummationByParts.jl
+++ b/src/SummationByParts.jl
@@ -83,6 +83,8 @@ immutable TriSBP{T} <: AbstractSBP{T}
   wface::Array{T,2}
   Q::Array{T,3}
   reorder::Bool
+  internal::Bool
+  vertices::Bool
 
   function TriSBP(;degree::Int=1, faceorder::Array{Int,1}=[1;2;3], 
                   bubble::Int=-1, reorder=false, internal=false, vertices=true)
@@ -118,7 +120,7 @@ immutable TriSBP{T} <: AbstractSBP{T}
     end
 
     new(degree, numnodes, numbndry, numfacenodes, facenodes, facenormal, cub,
-        vtx, w, wface, Q, reorder)
+        vtx, w, wface, Q, reorder, internal, vertices)
   end
 end
 

--- a/src/SummationByParts.jl
+++ b/src/SummationByParts.jl
@@ -26,7 +26,7 @@ export directionalDifferentiateElement!
 export volumeintegrate!, volumeIntegrateElement!
 export volumeintegrate_rev!, volumeIntegrateElement_rev!
 export calcMappingJacobian!, calcMappingJacobianElement!, mappingjacobian!
-export calcMappingJacobianRevDiff!
+export calcMappingJacobianRevDiff!, mappingjacobian_rev!
 export facenormal!, calcFaceNormals!
 export boundaryinterpolate!, boundaryFaceInterpolate!
 export boundaryinterpolate_rev!, boundaryFaceInterpolate_rev!

--- a/src/buildoperators.jl
+++ b/src/buildoperators.jl
@@ -522,8 +522,12 @@ function commuteerror{T,T2}(w::Array{T}, Qxpart::AbstractArray{T,2},
                             Qypart::AbstractArray{T,2},
                             Z::Array{T,2}, reducedsol::Array{T2})
   # build Qx and Qy
-  Qx = convert(Array{T2,2}, Qxpart)
-  Qy = convert(Array{T2,2}, Qypart)
+#  Qx = convert(Array{T2,2}, Qxpart)
+#  Qy = convert(Array{T2,2}, Qypart)
+  Qx = zeros(T2, size(Qxpart)...)
+  copy!(Qx, Qxpart)
+  Qy = zeros(T2, size(Qypart)...)
+  copy!(Qy, Qypart)
   numnodes = length(w)
   Qxnull = Z*reducedsol[1:size(Z,2)]
   Qynull = Z*reducedsol[size(Z,2)+1:end]

--- a/src/compile_time.jl
+++ b/src/compile_time.jl
@@ -1,0 +1,15 @@
+# things defined here would be defined using the pre-processor in C
+
+global const ENABLE_ASSERTS = true
+
+macro asserts_enabled(expr1)
+
+  if ENABLE_ASSERTS
+    return quote
+      $(esc(expr1))
+    end
+  else
+    return nothing
+  end
+
+end  # end macro

--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -103,8 +103,11 @@ function differentiateElement!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::Int,
                                                flux::AbstractArray{Tflx,1},
                                                res::AbstractArray{Tres,1},
                                                (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(flux,1) == size(res,1) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux,1) == size(res,1) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   for i = 1:sbp.numnodes
     for j = 1:sbp.numnodes
       res[i] += ±(sbp.Q[i,j,di]*flux[j])
@@ -117,9 +120,12 @@ function differentiateElement!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::Int,
                                                flux::AbstractArray{Tflx,2},
                                                res::AbstractArray{Tres,2},
                                                (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(flux,2) == size(res,2) )
-  @assert( length(flux) == length(res) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux,2) == size(res,2) )
+    @assert( length(flux) == length(res) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   for i = 1:sbp.numnodes
     for j = 1:sbp.numnodes
       for field = 1:size(flux,1)

--- a/src/differentiate_rev.jl
+++ b/src/differentiate_rev.jl
@@ -23,9 +23,12 @@ function differentiate_rev!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::Int,
                                             flux_bar::AbstractArray{Tflx,2},
                                             res_bar::AbstractArray{Tres,2},
                                             (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(flux_bar,1) && sbp.numnodes == size(res_bar,1) )
-  @assert( length(flux_bar) == length(res_bar) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux_bar,1) && sbp.numnodes == size(res_bar,1) )
+    @assert( length(flux_bar) == length(res_bar) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   tmp_bar = zero(Tres)
   for elem = 1:size(flux_bar,2)
     for i = 1:sbp.numnodes
@@ -43,9 +46,12 @@ function differentiate_rev!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::Int,
                                         flux_bar::AbstractArray{Tflx,3},
                                         res_bar::AbstractArray{Tres,3},
                                         (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(flux_bar,2) && sbp.numnodes == size(res_bar,2) )
-  @assert( length(flux_bar) == length(res_bar) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux_bar,2) && sbp.numnodes == size(res_bar,2) )
+    @assert( length(flux_bar) == length(res_bar) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   Hinv = zero(Tsbp)
   tmp_bar = zeros(Tres, size(flux_bar,1))
   for elem = 1:size(flux_bar,3)
@@ -87,8 +93,11 @@ function differentiateElement_rev!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::I
                                                flux_bar::AbstractArray{Tflx,1},
                                                res_bar::AbstractArray{Tres,1},
                                                (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(flux_bar,1) == size(res_bar,1) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux_bar,1) == size(res_bar,1) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   tmp_bar = zero(Tres)
   for i = 1:sbp.numnodes
     # res[i] /= sbp.w[i]    
@@ -104,9 +113,12 @@ function differentiateElement_rev!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::I
                                                flux_bar::AbstractArray{Tflx,2},
                                                res_bar::AbstractArray{Tres,2},
                                                (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(flux_bar,2) == size(res_bar,2) )
-  @assert( length(flux_bar) == length(res_bar) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux_bar,2) == size(res_bar,2) )
+    @assert( length(flux_bar) == length(res_bar) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   Hinv = zero(Tsbp)
   tmp_bar = zeros(Tres, size(flux_bar,1))
   for i = 1:sbp.numnodes

--- a/src/directionaldifferentiate.jl
+++ b/src/directionaldifferentiate.jl
@@ -26,7 +26,10 @@ function directionalDifferentiateElement!{Tsbp,Tmsh,Tsol}(sbp::AbstractSBP{Tsbp}
                                                           dir::Array{Tmsh,1},
                                                           u::AbstractArray{Tsol,1},
                                                           i::Int)
-  @assert( size(sbp.Q, 3) == size(dir,1) )
+  @asserts_enabled begin
+    @assert( size(sbp.Q, 3) == size(dir,1) )
+  end
+
   Ddir = zero(Tmsh)*zero(Tsol)
   for di = 1:size(sbp.Q, 3)
     tmp = zero(Tmsh)*zero(Tsol)
@@ -43,7 +46,10 @@ function directionalDifferentiateElement!{Tsbp,Tmsh,Tsol,Tres}(sbp::AbstractSBP{
                                                                u::AbstractArray{Tsol,2},
                                                                i::Int,
                                                                Ddir::Array{Tres,1})
-  @assert( size(sbp.Q, 3) == size(dir,1) )
+  @asserts_enabled begin
+    @assert( size(sbp.Q, 3) == size(dir,1) )
+  end
+
   for di = 1:size(sbp.Q, 3)
     tmp = zeros(Ddir)
     for j = 1:sbp.numnodes

--- a/src/faceinterpolate.jl
+++ b/src/faceinterpolate.jl
@@ -252,7 +252,7 @@ function interiorFaceInterpolate!{Tsbp,Tsol}(sbpface::AbstractFace{Tsbp},
   @assert( size(sbpface.interp,2) == size(ufaceL,2) == size(ufaceR,2) )
   for i = 1:sbpface.numnodes
     iR = sbpface.nbrperm[i,iface.orient]
-    for field=1:size(uL,1)
+    @simd for field=1:size(uL,1)
       ufaceL[field,i] = zero(Tsol)
       ufaceR[field,i] = zero(Tsol)
     end

--- a/src/mappingjacobian.jl
+++ b/src/mappingjacobian.jl
@@ -276,11 +276,15 @@ function calcMappingJacobianElement!{
              xlag::AbstractArray{Tmsh,2}, xsbp::AbstractArray{Tmsh,2},
              dξdx::AbstractArray{Tmsh,3}, jac::AbstractArray{Tmsh},
              Eone::AbstractArray{Tmsh,2}=Array(Tmsh,0,0))
-  @assert( sbp.numnodes == size(xsbp,2) == size(dξdx,3) == size(jac,1) )
-  @assert( size(xlag,1) == size(xref,1) == size(xsbp,1) == size(dξdx,1) 
-           == size(dξdx,2) == 2 )
-  numdof = binomial(mapdegree+2,2)
-  @assert( size(xlag,2) == size(xref,2) == numdof )
+
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(xsbp,2) == size(dξdx,3) == size(jac,1) )
+    @assert( size(xlag,1) == size(xref,1) == size(xsbp,1) == size(dξdx,1) 
+             == size(dξdx,2) == 2 )
+    numdof = binomial(mapdegree+2,2)
+    @assert( size(xlag,2) == size(xref,2) == numdof )
+  end
+
   # Step 1: find the polynomial mapping using xlag
   V = zeros(Tmsh, (numdof,numdof) )
   ptr = 1
@@ -328,12 +332,15 @@ function calcMappingJacobianElement!{
              xlag::AbstractArray{Tmsh,2}, xsbp::AbstractArray{Tmsh,2},
              dξdx::AbstractArray{Tmsh,3}, jac::AbstractArray{Tmsh},
              Eone::AbstractArray{Tmsh,2})
-  @assert( sbp.numnodes == size(xsbp,2) == size(dξdx,3) == size(jac,1) 
-           == size(Eone,1) )
-  @assert( size(xlag,1) == size(xref,1) == size(xsbp,1) == size(dξdx,1) 
-           == size(dξdx,2) == size(Eone,2) == 3 )
+
   numdof = binomial(mapdegree+3,3)
-  @assert( size(xlag,2) == size(xref,2) == numdof )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(xsbp,2) == size(dξdx,3) == size(jac,1) 
+             == size(Eone,1) )
+    @assert( size(xlag,1) == size(xref,1) == size(xsbp,1) == size(dξdx,1) 
+             == size(dξdx,2) == size(Eone,2) == 3 )
+    @assert( size(xlag,2) == size(xref,2) == numdof )
+  end
   # Step 1: find the polynomial mapping using xlag
   V = zeros(Tmsh, (numdof,numdof) )
   ptr = 1

--- a/src/mappingjacobian.jl
+++ b/src/mappingjacobian.jl
@@ -35,8 +35,8 @@ define the metric invariants.  *They are not needed by the 2-dimensional code*,
 and so this array can be passed empty in that case.
 
 """->
-function calcMappingJacobian!{Tsbp,Tmsh}(sbp::TriSBP{Tsbp}, mapdegree::Int,
-                                         xref::AbstractArray{Tmsh,2},
+function calcMappingJacobian!{Tsbp,Tmsh, T2}(sbp::TriSBP{Tsbp}, mapdegree::Int,
+                                         xref::AbstractArray{T2, 2},
                                          xlag::AbstractArray{Tmsh,3},
                                          xsbp::AbstractArray{Tmsh,3},
                                          dξdx::AbstractArray{Tmsh,4},

--- a/src/mappingjacobian.jl
+++ b/src/mappingjacobian.jl
@@ -685,7 +685,7 @@ function mappingjacobian!{Tsbp,Tmsh}(sbp::TetSBP{Tsbp},
   # calculate the derivative of the coordinates with respect to (xi,eta,zeta)
   # using the SBP operator
   for di = 1:3
-    differentiate!(sbp, di, x, sub(dxdξ,:,:,:,di)) 
+    differentiate!(sbp, di, x, sview(dxdξ,:,:,:,di)) 
   end
   fill!(dξdx, zero(Tmsh))
   # calculate the metrics
@@ -756,7 +756,7 @@ function mappingjacobian_rev!{Tsbp,Tmsh}(sbp::TriSBP{Tsbp},
     # compute the coordinate derivatives
     fill!(work, zero(Tmsh))
     for di = 1:2
-      differentiateElement!(sbp, di, sub(x,:,:,elem), sub(work,:,:,di)) 
+      differentiateElement!(sbp, di, sview(x,:,:,elem), sview(work,:,:,di)) 
     end
     # compute the scaled metrics: could also pass these in to avoid recomputing
     # them...
@@ -783,7 +783,7 @@ function mappingjacobian_rev!{Tsbp,Tmsh}(sbp::TriSBP{Tsbp},
       work[1,i,1] += dξdx_bar[2,2,i,elem]
     end
     for di = 1:2
-      differentiateElement_rev!(sbp, di, sub(x_bar,:,:,elem), sub(work,:,:,di)) 
+      differentiateElement_rev!(sbp, di, sview(x_bar,:,:,elem), sview(work,:,:,di)) 
     end
   end
 end
@@ -807,7 +807,7 @@ function mappingjacobian_rev!{Tsbp,Tmsh}(sbp::TetSBP{Tsbp},
     # compute the coordinate derivatives
     fill!(work, zero(Tmsh))
     for di = 1:3
-      differentiateElement!(sbp, di, sub(x,:,:,elem), sub(work,:,:,di)) 
+      differentiateElement!(sbp, di, sview(x,:,:,elem), sview(work,:,:,di)) 
     end
     permutedims!(dxdξ, work, [1,3,2]) # probably slow
 
@@ -863,9 +863,9 @@ function mappingjacobian_rev!{Tsbp,Tmsh}(sbp::TetSBP{Tsbp},
 
     permutedims!(work, dxdξ_bar, [1,3,2]) # probably slow    
     for di = 1:3
-      #differentiate!(sbp, di, x, sub(dxdξ,:,:,:,di))
-      differentiateElement_rev!(sbp, di, sub(x_bar,:,:,elem),
-                                sub(work,:,:,di))
+      #differentiate!(sbp, di, x, sview(dxdξ,:,:,:,di))
+      differentiateElement_rev!(sbp, di, sview(x_bar,:,:,elem),
+                                sview(work,:,:,di))
     end
   end # loop over elements
 end
@@ -884,7 +884,7 @@ function mappingjacobian!{Tsbp,Tmsh}(sbp::TetSBP{Tsbp},
   # calculate the derivative of the coordinates with respect to (xi,eta,zeta)
   # using the SBP operator
   for di = 1:3
-    differentiate!(sbp, di, x, sub(dxdξ,:,:,:,di)) 
+    differentiate!(sbp, di, x, sview(dxdξ,:,:,:,di)) 
   end
   fill!(dξdx, zero(Tmsh))
   # calculate the metrics: the outer loop calculates the derivatives of

--- a/src/mappingjacobianrevdiff.jl
+++ b/src/mappingjacobianrevdiff.jl
@@ -31,7 +31,7 @@ the 3D case, but Eone_r needs to be supplied in both 2D and 3D.
 
 """->
 function calcMappingJacobianRevDiff!{
-  Tsbp,Tmsh}(sbp::TriSBP{Tsbp}, mapdegree::Int, xref::AbstractArray{Tmsh,2},
+  Tsbp,Tmsh, T2}(sbp::TriSBP{Tsbp}, mapdegree::Int, xref::AbstractArray{T2,2},
              xlag_r::AbstractArray{Tmsh,3}, xsbp_r::AbstractArray{Tmsh,3},
              dξdx::AbstractArray{Tmsh,4}, dξdx_r::AbstractArray{Tmsh,4},
              jac::AbstractArray{Tmsh,2}, jac_r::AbstractArray{Tmsh,2},

--- a/src/symcubatures.jl
+++ b/src/symcubatures.jl
@@ -1175,7 +1175,7 @@ dimension as the cubature; for example, a line quadrature can be over a line in
 * `x`: cubature's nodal coordinates (potentially in a subspace)
 
 """->
-function calcnodes{T}(cub::LineSymCub{T}, vtx::Array{T,2})
+function calcnodes{T}(cub::LineSymCub, vtx::Array{T,2})
   @assert(cub.numparams >= 0)
   @assert(cub.numnodes >= 1)
   @assert(size(vtx,1) == 2)
@@ -1206,7 +1206,7 @@ function calcnodes{T}(cub::LineSymCub{T}, vtx::Array{T,2})
   return x
 end
 
-function calcnodes{T}(cub::TriSymCub{T}, vtx::Array{T,2})
+function calcnodes{T}(cub::TriSymCub, vtx::Array{T,2})
   @assert(cub.numparams >= 0)
   @assert(cub.numnodes >= 1)
   @assert(size(vtx,1) == 3 && size(vtx,2) >= 2)
@@ -1274,7 +1274,7 @@ function calcnodes{T}(cub::TriSymCub{T}, vtx::Array{T,2})
   return x
 end
 
-function calcnodes{T}(cub::TetSymCub{T}, vtx::Array{T,2})
+function calcnodes{T}(cub::TetSymCub, vtx::Array{T,2})
   @assert(cub.numparams >= 0)
   @assert(cub.numnodes >= 1)
   @assert(size(vtx,1) == 4 && size(vtx,2) >= 3)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -357,3 +357,5 @@ function basispursuit!(A::AbstractArray{Float64,2}, b::AbstractVector{Float64},
   end
 end
 
+
+

--- a/src/volumeintegrate.jl
+++ b/src/volumeintegrate.jl
@@ -91,7 +91,10 @@ function volumeIntegrateElement!{Tsbp,Tsol,Tres}(sbp::AbstractSBP{Tsbp},
                                                  u::AbstractArray{Tsol,1},
                                                  res::AbstractArray{Tres,1},
                                                  (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(u,1) == size(res,1) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(u,1) == size(res,1) )
+  end
+
   for i = 1:sbp.numnodes
     res[i] += ±(sbp.w[i]*u[i])
   end
@@ -101,8 +104,11 @@ function volumeIntegrateElement!{Tsbp,Tsol,Tres}(sbp::AbstractSBP{Tsbp},
                                                  u::AbstractArray{Tsol,2},
                                                  res::AbstractArray{Tres,2},
                                                  (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(u,2) == size(res,2) )
-  @assert( length(u) == length(res) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(u,2) == size(res,2) )
+    @assert( length(u) == length(res) )
+  end
+
   for i = 1:sbp.numnodes
     for field = 1:size(u,1)
       res[field,i] += ±(sbp.w[i]*u[field,i])

--- a/src/volumeintegrate_rev.jl
+++ b/src/volumeintegrate_rev.jl
@@ -73,7 +73,10 @@ function volumeIntegrateElement_rev!{Tsbp,Tsol,Tres}(sbp::AbstractSBP{Tsbp},
                                                      u_bar::AbstractArray{Tsol,1},
                                                      res_bar::AbstractArray{Tres,1},
                                                      (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(u_bar,1) == size(res_bar,1) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(u_bar,1) == size(res_bar,1) )
+  end
+
   for i = 1:sbp.numnodes
     # res[i] += ±(sbp.w[i]*u[i])
     u_bar[i] += ±(sbp.w[i]*res_bar[i])
@@ -84,8 +87,12 @@ function volumeIntegrateElement_rev!{Tsbp,Tsol,Tres}(sbp::AbstractSBP{Tsbp},
                                                      u_bar::AbstractArray{Tsol,2},
                                                      res_bar::AbstractArray{Tres,2},
                                                      (±)::UnaryFunctor=Add())
-  @assert( sbp.numnodes == size(u_bar,2) == size(res_bar,2) )
-  @assert( length(u_bar) == length(res_bar) )
+
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(u_bar,2) == size(res_bar,2) )
+    @assert( length(u_bar) == length(res_bar) )
+  end
+
   for i = 1:sbp.numnodes
     for field = 1:size(u_bar,1)
       # res[field,i] += ±(sbp.w[i]*u[field,i])

--- a/src/weakdifferentiate.jl
+++ b/src/weakdifferentiate.jl
@@ -146,11 +146,11 @@ function weakDifferentiateElement!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp},
                                                    di::Int,
                                                    flux::AbstractArray{Tflx,2},
                                                    res::AbstractArray{Tres,2},
-                                                   (±)::UnaryFunctor=Add();
+                                                   (±)::UnaryFunctor=Add(),
                                                    trans::Bool=false)
-  @assert( sbp.numnodes == size(flux,2) == size(res,2) )
-  @assert( length(flux) == length(res) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+#  @assert( sbp.numnodes == size(flux,2) == size(res,2) )
+#  @assert( length(flux) == length(res) )
+#  @assert( di > 0 && di <= size(sbp.Q,3) )
   if trans # apply transposed Q
     for i = 1:sbp.numnodes
       for j = 1:sbp.numnodes

--- a/src/weakdifferentiate.jl
+++ b/src/weakdifferentiate.jl
@@ -123,10 +123,13 @@ function weakDifferentiateElement!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp},
                                                    di::Int,
                                                    flux::AbstractArray{Tflx,1},
                                                    res::AbstractArray{Tres,1},
-                                                   (±)::UnaryFunctor=Add();
+                                                   (±)::UnaryFunctor=Add(),
                                                    trans::Bool=false)
-  @assert( sbp.numnodes == size(flux,1) == size(res,1) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux,1) == size(res,1) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   if trans # apply transposed Q
     for i = 1:sbp.numnodes
       for j = 1:sbp.numnodes
@@ -148,9 +151,12 @@ function weakDifferentiateElement!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp},
                                                    res::AbstractArray{Tres,2},
                                                    (±)::UnaryFunctor=Add(),
                                                    trans::Bool=false)
-#  @assert( sbp.numnodes == size(flux,2) == size(res,2) )
-#  @assert( length(flux) == length(res) )
-#  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux,2) == size(res,2) )
+    @assert( length(flux) == length(res) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   if trans # apply transposed Q
     for i = 1:sbp.numnodes
       for j = 1:sbp.numnodes

--- a/src/weakdifferentiate_rev.jl
+++ b/src/weakdifferentiate_rev.jl
@@ -106,10 +106,13 @@ differentiated with respect to the primal version's `flux` variable.
 function weakDifferentiateElement_rev!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::Int,
                                                        flux_bar::AbstractArray{Tflx,1},
                                                        res_bar::AbstractArray{Tres,1},
-                                                       (±)::UnaryFunctor=Add();
+                                                       (±)::UnaryFunctor=Add(),
                                                        trans::Bool=false)
-  @assert( sbp.numnodes == size(flux_bar,1) == size(res_bar,1) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux_bar,1) == size(res_bar,1) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   if trans # apply transposed Q
     for i = 1:sbp.numnodes
       for j = 1:sbp.numnodes
@@ -130,11 +133,14 @@ end
 function weakDifferentiateElement_rev!{Tsbp,Tflx,Tres}(sbp::AbstractSBP{Tsbp}, di::Int,
                                                        flux_bar::AbstractArray{Tflx,2},
                                                        res_bar::AbstractArray{Tres,2},
-                                                       (±)::UnaryFunctor=Add();
+                                                       (±)::UnaryFunctor=Add(),
                                                        trans::Bool=false)
-  @assert( sbp.numnodes == size(flux_bar,2) == size(res_bar,2) )
-  @assert( length(flux_bar) == length(res_bar) )
-  @assert( di > 0 && di <= size(sbp.Q,3) )
+  @asserts_enabled begin
+    @assert( sbp.numnodes == size(flux_bar,2) == size(res_bar,2) )
+    @assert( length(flux_bar) == length(res_bar) )
+    @assert( di > 0 && di <= size(sbp.Q,3) )
+  end
+
   if trans # apply transposed Q
     for i = 1:sbp.numnodes
       for j = 1:sbp.numnodes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ import ODLCommonTools.sview
 
 view = ArrayViews.view
 
+#=
 include("test_orthopoly.jl")
 include("test_symcubatures.jl")
 include("test_cubature.jl")
@@ -22,13 +23,15 @@ include("test_directionaldifferentiate.jl")
 include("test_volumeintegrate.jl")
 include("test_volumeintegrate_rev.jl")
 include("test_facenormal.jl")
+=#
 include("test_mappingjacobian.jl")
 include("test_mappingjacobianrevdiff.jl")
+#=
 include("test_faceinterpolate.jl")
 include("test_faceinterpolate_rev.jl")
 include("test_faceintegrate.jl")
 include("test_faceintegrate_rev.jl")
 include("test_edgestabilize.jl")
 include("test_utils.jl")
-
+=#
 FactCheck.exitstatus()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ import ODLCommonTools.sview
 
 view = ArrayViews.view
 
-#=
+
 include("test_orthopoly.jl")
 include("test_symcubatures.jl")
 include("test_cubature.jl")
@@ -23,16 +23,16 @@ include("test_directionaldifferentiate.jl")
 include("test_volumeintegrate.jl")
 include("test_volumeintegrate_rev.jl")
 include("test_facenormal.jl")
-=#
+
 include("test_mappingjacobian.jl")
 #include("test_mappingjacobianrevdiff.jl")
 include("test_mappingjacobian_rev.jl")
-#=
+
 include("test_faceinterpolate.jl")
 include("test_faceinterpolate_rev.jl")
 include("test_faceintegrate.jl")
 include("test_faceintegrate_rev.jl")
 include("test_edgestabilize.jl")
 include("test_utils.jl")
-=#
+
 FactCheck.exitstatus()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,8 @@ include("test_volumeintegrate_rev.jl")
 include("test_facenormal.jl")
 =#
 include("test_mappingjacobian.jl")
-include("test_mappingjacobianrevdiff.jl")
+#include("test_mappingjacobianrevdiff.jl")
+include("test_mappingjacobian_rev.jl")
 #=
 include("test_faceinterpolate.jl")
 include("test_faceinterpolate_rev.jl")

--- a/test/test_mappingjacobian_rev.jl
+++ b/test/test_mappingjacobian_rev.jl
@@ -1,0 +1,280 @@
+facts("Testing SummationByParts Module (reverse-diff of mapping Jacobian)...") do
+#=
+  context("Testing calcMappingJacobian_rev! (TriSBP method)") do
+    # build a curvilinear Lagrangian element, and verify against randomly
+    # perturbed Lagrangian nodes using complex step
+    for p = 1:4
+      sbp = TriSBP{Float64}(degree=p, internal=false)
+
+      function mapping(ξ)
+        return [0.5*(ξ[1]+1) + (0.5*(ξ[1]+1))^p;
+                0.5*(ξ[2]+1) + (0.5*(ξ[2]+1))^p + (0.5*(ξ[1]+1))^(p-1)]
+      end
+      function diffmapping(ξ)
+        return [(0.5 + 0.5*p*(0.5*(ξ[1]+1))^(p-1)) 0.0;
+                (0.5*(p-1)*(0.5*(ξ[1]+1))^max(p-2,0))
+                (0.5 + 0.5*p*(0.5*(ξ[2]+1))^(p-1))]
+      end      
+
+      numdof = div((p+2)*(p+3),2)
+      # set the coordinates of the reference and mapped nodes of the Lagrange
+      # element
+      xref = zeros(2,numdof)
+      xlag = zeros(2,numdof,1)
+      ptr = 1
+      for r = 0:p+1
+        for j = 0:r
+          i = r-j
+          xref[1,ptr] = 2*i/(p+1) - 1
+          xref[2,ptr] = 2*j/(p+1) - 1
+          xlag[:,ptr,1] = mapping(xref[:,ptr])
+          ptr += 1
+        end
+      end
+      # compute the SBP nodes and the mapping Jacobian
+      xsbp = zeros(2,sbp.numnodes,1)
+      dξdx = zeros(2,2,sbp.numnodes,1)
+      jac = zeros(sbp.numnodes,1)
+      calcMappingJacobian!(sbp, p+1, xref, xlag, xsbp, dξdx, jac)
+
+      # These arrays are meant to mimic the derivative of the residual with
+      # respect to xsbp, dξdx, and jac
+      dRdxsbp = randn(2,sbp.numnodes,1)
+      dRddξdx = randn(2,2,sbp.numnodes,1)
+      dRdjac = randn(sbp.numnodes,1)
+      
+      # evaluate complex-step gradient to get dRdxlag
+      xsbp_c = zeros(Complex{Float64}, (2,sbp.numnodes,1))
+      dξdx_c = zeros(Complex{Float64}, (2,2,sbp.numnodes,1))
+      jac_c = zeros(Complex{Float64}, (sbp.numnodes,1))
+      xref_c = complex(xref, 0.0)
+      dRdxlag_cmplx = zeros(2,numdof,1)
+      eps_cmplx = 1e-60
+      for di = 1:2
+        for nd = 1:numdof
+          xlag_c = complex(xlag, 0.0)
+          xlag_c[di,nd,1] += complex(0.0, eps_cmplx)
+          # compute the complex perturbed SBP nodes and the mapping Jacobian
+          calcMappingJacobian!(sbp, p+1, xref_c, xlag_c, xsbp_c, dξdx_c, jac_c)
+          dRdxlag_cmplx[di,nd,1] +=
+            (dot(vec(dRdxsbp[:,:,1]),vec(imag(xsbp_c))) +
+             dot(vec(dRddξdx[:,:,:,1]),vec(imag(dξdx_c))) +
+             dot(vec(dRdjac[:,1]),vec(imag(jac_c))))
+        end
+      end
+      scale!(dRdxlag_cmplx,1/eps_cmplx)
+
+      # use reverse mode to get dRdxlag
+      dRdxlag = zeros(2,numdof,1)
+      Eone_bar = zeros(sbp.numnodes,2,1)
+      calcMappingJacobian_rev!(sbp, p+1, xref, xlag, dRdxlag, dRdxsbp, dRddξdx,
+                               dRdjac, Eone_bar)
+
+      @fact dRdxlag --> roughly(dRdxlag_cmplx, atol=1e-14)
+    end
+  end
+
+  context("Testing calcMappingJacobian_rev! (TetSBP method)") do
+    # build a curvilinear Lagrangian element, and verify against randomly
+    # perturbed Lagrangian nodes using complex step
+    for p = 1:4
+      sbp = TetSBP{Float64}(degree=p, internal=false)
+      sbpface = TetFace{Float64}(p, sbp.cub, sbp.vtx)
+      function mapping(ξ)
+        x = 0.5*(ξ[1]+1) + (0.5*(ξ[1]+1))^(p+1)
+        y = 0.5*(ξ[2]+1) + (0.5*(ξ[2]+1))^(p+1)
+        z = 0.5*(ξ[3]+1) + (0.5*(ξ[3]+1))^(p+1)
+        fac = 0.5
+        return [fac*x - fac*y; fac*x + fac*y; z]
+      end
+      # set the coordinates of the Lagrangian face nodes in reference and
+      # physical space
+      numdof = div((p+2)*(p+3),2)
+      xref = zeros(2,numdof)
+      ptr = 1
+      for r = 0:p+1
+        for j = 0:r
+          i = r-j
+          xref[1,ptr] = 2*i/(p+1) - 1.0
+          xref[2,ptr] = 2*j/(p+1) - 1.0
+          ptr += 1
+        end
+      end
+      xlag = zeros(3,numdof,4)
+      for i = 1:numdof
+        xlag[:,i,1] = mapping([xref[1,i]; xref[2,i]; -1.0])
+        xlag[:,i,2] = mapping([xref[2,i]; -1.0; xref[1,i]])
+        xlag[:,i,3] = mapping([xref[2,i]; xref[1,i];
+                               -1.0 - xref[1,i] - xref[2,i]])
+        xlag[:,i,4] = mapping([-1.0; xref[1,i]; xref[2,i]]) 
+      end
+      # get the SBP face nodes and the normal vector
+      xsbp = zeros(3,sbpface.numnodes,4)
+      nrm = zeros(3,sbpface.numnodes,4)
+      E = zeros(sbp.numnodes,sbp.numnodes,3)
+      for f = 1:4
+        facenormal!(sbpface, p+1, xref, sview(xlag,:,:,f),
+                    sview(xsbp,:,:,f), sview(nrm,:,:,f))
+        for di = 1:3
+          # for the given Lagrangian nodes, the face-normal is inward pointing,
+          # so subtract to reverse sign
+          E[sbpface.perm[:,f],sbpface.perm[:,f],di] -= 
+          sbpface.interp*diagm(sbpface.wface.*vec(nrm[di,:,f]))*sbpface.interp.'
+        end
+      end
+      Eone = zeros(sbp.numnodes,3,1)
+      Eone = reshape(sum(E, 2), (sbp.numnodes,3,1))
+      # now set the coordinates of the Lagrangian element nodes in reference and
+      # physical space
+      numdof = binomial(p+1+3,3)
+      xref = zeros(3,numdof)
+      ptr = 1
+      for r = 0:(p+1)
+        for k = 0:r
+          for j = 0:r-k
+            i = r-j-k
+            xref[1,ptr] = 2*i/(p+1) - 1.0
+            xref[2,ptr] = 2*j/(p+1) - 1.0
+            xref[3,ptr] = 2*k/(p+1) - 1.0
+            ptr += 1
+          end
+        end
+      end
+      xlag = zeros(3,numdof,1)
+      for i = 1:numdof
+        xlag[:,i,1] = mapping(xref[:,i])
+      end
+      # compute the SBP nodes and the mapping Jacobian
+      xsbp = zeros(3,sbp.numnodes,1)
+      dξdx = zeros(3,3,sbp.numnodes,1)
+      jac = zeros(sbp.numnodes,1)
+      calcMappingJacobian!(sbp, p+1, xref, xlag, xsbp, dξdx, jac, Eone)
+
+      # These arrays are meant to mimic the derivative of the residual with
+      # respect to xsbp, dξdx, and jac
+      dRdxsbp = randn(3,sbp.numnodes,1)
+      dRddξdx = randn(3,3,sbp.numnodes,1)
+      dRdjac = randn(sbp.numnodes,1)
+      
+      # evaluate complex-step gradient to get dRdxlag
+      xsbp_c = zeros(Complex{Float64}, (3,sbp.numnodes,1))
+      dξdx_c = zeros(Complex{Float64}, (3,3,sbp.numnodes,1))
+      jac_c = zeros(Complex{Float64}, (sbp.numnodes,1))
+      xref_c = complex(xref, 0.0)                
+      Eone_c = complex(Eone, 0.0)
+      xlag_c = complex(xlag, 0.0)      
+      dRdxlag_cmplx = zeros(3,numdof,1)
+      eps_cmplx = 1e-60
+      for di = 1:3
+        for nd = 1:numdof
+          xlag_c[di,nd,1] += complex(0.0, eps_cmplx)
+          # compute the complex perturbed SBP nodes and the mapping Jacobian
+          calcMappingJacobian!(sbp, p+1, xref_c, xlag_c, xsbp_c, dξdx_c, jac_c,
+                               Eone_c)
+          xlag_c[di,nd,1] -= complex(0.0, eps_cmplx)
+          dRdxlag_cmplx[di,nd,1] +=
+            (dot(vec(dRdxsbp[:,:,1]),vec(imag(xsbp_c))) +
+             dot(vec(dRddξdx[:,:,:,1]),vec(imag(dξdx_c))) +
+             dot(vec(dRdjac[:,1]),vec(imag(jac_c))))
+        end
+      end
+      scale!(dRdxlag_cmplx,1/eps_cmplx)      
+
+      # evaluate complex-step gradient to get dRdEone
+      dRdEone_cmplx = zeros(sbp.numnodes,3,1)
+      for di = 1:3
+        for i = 1:sbp.numnodes
+          Eone_c[i,di,1] += complex(0.0, eps_cmplx)
+          # compute the complex perturbed SBP nodes and the mapping Jacobian
+          calcMappingJacobian!(sbp, p+1, xref_c, xlag_c, xsbp_c, dξdx_c, jac_c,
+                               Eone_c)
+          Eone_c[i,di,1] -= complex(0.0, eps_cmplx)
+          dRdEone_cmplx[i,di,1] +=
+            (dot(vec(dRdxsbp[:,:,1]),vec(imag(xsbp_c))) +
+             dot(vec(dRddξdx[:,:,:,1]),vec(imag(dξdx_c))) +
+             dot(vec(dRdjac[:,1]),vec(imag(jac_c))))
+        end
+      end
+      scale!(dRdEone_cmplx,1/eps_cmplx)      
+      
+      # use reverse mode to get dRdxlag and dRdEone
+      dRdxlag = zeros(3,numdof,1)
+      dRdEone = zeros(sbp.numnodes,3,1)
+      calcMappingJacobian_rev!(sbp, p+1, xref, xlag, dRdxlag, dRdxsbp, dRddξdx,
+                               dRdjac, dRdEone)
+      @fact dRdxlag --> roughly(dRdxlag_cmplx, atol=1e-14)
+      @fact dRdEone --> roughly(dRdEone_cmplx, atol=1e-14)
+    end
+  end
+=#
+  context("Testing mappingjacobian_rev! (TriSBP method)") do
+    # build one element grid, and verify against randomly
+    # perturbed SBP nodes using complex step
+    for p = 1:4
+      sbp = TriSBP{Float64}(degree=p)
+      vtx = 2.0.*sbp.vtx
+      x = zeros(Float64, (2,sbp.numnodes,1))
+      x[:,:,1] = calcnodes(sbp, vtx)
+      x_bar = zeros(x)
+      dξdx_bar = randn(2,2,sbp.numnodes,1)
+      jac_bar = randn(sbp.numnodes,1)
+
+      x_bar_cs = zeros(x)
+      x_cmplx = complex(x, zeros(x))
+      dξdx_cmplx = zeros(Complex128, (2,2,sbp.numnodes,1))
+      jac_cmplx = zeros(Complex128, (sbp.numnodes,1))
+      ceps = 1e-60
+      for i = 1:sbp.numnodes
+        for di = 1:2
+          x_cmplx[di,i,1] += complex(0.0, ceps)
+          mappingjacobian!(sbp, x_cmplx, dξdx_cmplx, jac_cmplx)
+          x_cmplx[di,i,1] -= complex(0.0, ceps)
+          x_bar_cs[di,i,1] += (dot(vec(dξdx_bar),vec(imag(dξdx_cmplx))) +
+                               dot(vec(jac_bar),vec(imag(jac_cmplx))))
+        end
+      end
+      scale!(x_bar_cs, 1/ceps)
+
+      # this needs to come at the end, because dξdx_bar is modified
+      mappingjacobian_rev!(sbp, x, x_bar, dξdx_bar, jac_bar)
+      
+      @fact x_bar --> roughly(x_bar_cs, atol=1e-14)      
+    end
+  end
+
+  context("Testing mappingjacobian_rev! (TetSBP method)") do
+    # build one element grid, and verify against randomly
+    # perturbed SBP nodes using complex step
+    for p = 1:4
+      sbp = TetSBP{Float64}(degree=p)
+      vtx = [0. 0. 0.; 2. 0. 0.; 0. 2. 0.; 0. 0. 2.]
+      x = zeros(Float64, (3,sbp.numnodes,1))
+      x[:,:,1] = calcnodes(sbp, vtx)
+      x_bar = zeros(x)
+      dξdx_bar = randn(3,3,sbp.numnodes,1)
+      jac_bar = randn(sbp.numnodes,1)
+
+      x_bar_cs = zeros(x)
+      x_cmplx = complex(x, zeros(x))
+      dξdx_cmplx = zeros(Complex128, (3,3,sbp.numnodes,1))
+      jac_cmplx = zeros(Complex128, (sbp.numnodes,1))
+      ceps = 1e-60
+      for i = 1:sbp.numnodes
+        for di = 1:3
+          x_cmplx[di,i,1] += complex(0.0, ceps)
+          mappingjacobian!(sbp, x_cmplx, dξdx_cmplx, jac_cmplx)
+          x_cmplx[di,i,1] -= complex(0.0, ceps)
+          x_bar_cs[di,i,1] += (dot(vec(dξdx_bar),vec(imag(dξdx_cmplx))) +
+                               dot(vec(jac_bar),vec(imag(jac_cmplx))))
+        end
+      end
+      scale!(x_bar_cs, 1/ceps)
+
+      # this needs to come at the end, because dξdx_bar may be modified
+      mappingjacobian_rev!(sbp, x, x_bar, dξdx_bar, jac_bar)
+      
+      @fact x_bar --> roughly(x_bar_cs, atol=1e-14)      
+    end
+  end
+
+end

--- a/test/test_weakdifferentiate_rev.jl
+++ b/test/test_weakdifferentiate_rev.jl
@@ -56,12 +56,12 @@ facts("Testing SummationByParts Module (reverse-diff of weak differentiate metho
           vQ = zeros(v)
           for di = 1:2            
             # verify that v^T Q = (Q^T v)^T
-            weakDifferentiateElement!(sbp, di, v, Qv, trans=true)
-            weakDifferentiateElement_rev!(sbp, di, vQ, v, trans=false)
+            weakDifferentiateElement!(sbp, di, v, Qv, SummationByParts.Add(), true)
+            weakDifferentiateElement_rev!(sbp, di, vQ, v, SummationByParts.Add(), false)
             @fact Qv --> roughly(vQ, atol=1e-15)
             # verify that v^T Q^T = (Qv)^T
-            weakDifferentiateElement!(sbp, di, v, Qv, trans=false)
-            weakDifferentiateElement_rev!(sbp, di, vQ, v, trans=true)
+            weakDifferentiateElement!(sbp, di, v, Qv, SummationByParts.Add(), false)
+            weakDifferentiateElement_rev!(sbp, di, vQ, v, SummationByParts.Add(), true)
             @fact Qv --> roughly(vQ, atol=1e-15)
           end
         end
@@ -79,12 +79,12 @@ facts("Testing SummationByParts Module (reverse-diff of weak differentiate metho
           vQ = zeros(v)
           for di = 1:2            
             # verify that v^T Q = (Q^T v)^T
-            weakDifferentiateElement!(sbp, di, v, Qv, trans=true)
-            weakDifferentiateElement_rev!(sbp, di, vQ, v, trans=false)
+            weakDifferentiateElement!(sbp, di, v, Qv, SummationByParts.Add(), true)
+            weakDifferentiateElement_rev!(sbp, di, vQ, v, SummationByParts.Add(), false)
             @fact Qv --> roughly(vQ, atol=1e-15)
             # verify that v^T Q^T = (Qv)^T
-            weakDifferentiateElement!(sbp, di, v, Qv, trans=false)
-            weakDifferentiateElement_rev!(sbp, di, vQ, v, trans=true)
+            weakDifferentiateElement!(sbp, di, v, Qv, SummationByParts.Add(), false)
+            weakDifferentiateElement_rev!(sbp, di, vQ, v, SummationByParts.Add(), true)
             @fact Qv --> roughly(vQ, atol=1e-15)
           end
         end


### PR DESCRIPTION
Miscellaneous changes.  Off the top of my head:
  * loosen type signature of something in `SymCubatures` so we don't `Tsbp=Complex128` to operate on complex data
  * add macro to disable asserts in the element based routines.  Benchmarks showed this is important for performance
  * change the `trans` argument in `weakDifferentiateElement` from keyword to position.  Benchmarking showed this is important