### PR TITLE
make separate outer constructor for 2p omegas

### DIFF
--- a/src/SummationByParts.jl
+++ b/src/SummationByParts.jl
@@ -16,7 +16,7 @@ using .SymCubatures
 using .Cubature
 
 export AbstractSBP, TriSBP, TetSBP, SparseTriSBP, SparseTetSBP
-export getTriSBPGamma, getTriSBPOmega, getTriSBPWithDiagE
+export getTriSBPGamma, getTriSBPOmega, getTriSBPOmega2, getTriSBPWithDiagE
 export getTetSBPGamma, getTetSBPOmega, getTetSBPWithDiagE
 export AbstractFace, TriFace, TetFace
 export getTriFaceForDiagE, getTetFaceForDiagE

--- a/src/outerconstructors.jl
+++ b/src/outerconstructors.jl
@@ -60,13 +60,35 @@ Returns SBP-Omega type elements, that have no nodes on the element boundary
 
 """->
 function getTriSBPOmega(;degree::Int=1, Tsbp::Type=Float64)
-  #return TriSBP{Tsbp}(degree=degree, internal=true, vertices=false)
+  return TriSBP{Tsbp}(degree=degree, internal=true, vertices=false)
+end
+
+"""
+### SBP.getTriSBPOmega2
+
+Like getTRISBPomega, but ensures the operator has a degree 2p cubature
+rule
+
+**Inputs**
+
+* `degree`: maximum polynomial degree for which the derivatives are exact
+* `Tsbp`: floating point type used for the operators
+
+**Returns**
+
+* `sbp`: an SBP-Omega type operator of the appropriate degree
+
+"""
+function getTriSBPOmega2(;degree::Int=1, Tsbp::Type=Float64)
+
   cub, vtx = tricubature(2*degree, Tsbp, internal=true,
                          vertices=false)
   Q = zeros(Tsbp, (cub.numnodes, cub.numnodes, 2))
   w, Q = SummationByParts.buildoperators(cub, vtx, degree)
-  TriSBP{Tsbp}(degree, cub, vtx, w, Q)
+
+  return TriSBP{Tsbp}(degree, cub, vtx, w, Q)
 end
+
 
 function getTriSBPWithDiagE(;degree::Int=1, Tsbp::Type=Float64,
                             vertices::Bool=true)

--- a/test/printnodes.jl
+++ b/test/printnodes.jl
@@ -39,7 +39,7 @@ end
 function printTriOmegaNodes(degree::Int,
                             filename::AbstractString="nodes.dat")
   @assert( degree >= 1 && degree <= 4)
-  sbp = getTriSBPOmega(degree=degree)
+  sbp = getTriSBPOmega2(degree=degree)
   sbpface = TriFace{Float64}(degree, sbp.cub, [-1. -1; 1 -1; -1 1])
   # compute the volume nodes
   vtx = [0.0 0.0; 1 0.0; 0.5 sqrt(3)*0.5]


### PR DESCRIPTION
This PR makes a separate outer constructor for the 2p Omega operators and restores the original outer constructor for the not-necessarily 2p Omega.  Presumably these should return the same operators for p=1 and p=2.  The goal is to make both operators accessible at the same time in case we want to compare their performance (and it makes some things in `PumiInterface.jl` easier).